### PR TITLE
修复潜在的未定义 RT_PKG_MQTT_THREAD_STACK_SIZE 造成的编译错误。并为使用TLS连接的时候增加堆栈大小检查

### DIFF
--- a/MQTTClient-RT/paho_mqtt_pipe.c
+++ b/MQTTClient-RT/paho_mqtt_pipe.c
@@ -27,6 +27,20 @@
 #error "Please update the 'rtdbg.h' file to GitHub latest version (https://github.com/RT-Thread/rt-thread/blob/master/include/rtdbg.h)"
 #endif
 
+#ifndef RT_PKG_MQTT_THREAD_STACK_SIZE
+#ifdef MQTT_USING_TLS
+#define RT_PKG_MQTT_THREAD_STACK_SIZE 6144
+#else
+#define RT_PKG_MQTT_THREAD_STACK_SIZE 4096
+#endif
+#endif
+
+#ifdef MQTT_USING_TLS
+#if (RT_PKG_MQTT_THREAD_STACK_SIZE < 6144)
+#error "MQTT using tls, please increase MQTT thread stack size up to 6K via menuconfig tool!"
+#endif
+#endif
+
 /*
  * resolve server address
  * @param server the server sockaddress

--- a/MQTTClient-RT/paho_mqtt_udp.c
+++ b/MQTTClient-RT/paho_mqtt_udp.c
@@ -23,6 +23,20 @@
 #error "must enable RT_LWIP_NETIF_LOOPBACK for publish!"
 #endif /* LWIP_NETIF_LOOPBACK */
 
+#ifndef RT_PKG_MQTT_THREAD_STACK_SIZE
+#ifdef MQTT_USING_TLS
+#define RT_PKG_MQTT_THREAD_STACK_SIZE 6144
+#else
+#define RT_PKG_MQTT_THREAD_STACK_SIZE 4096
+#endif
+#endif
+
+#ifdef MQTT_USING_TLS
+#if (RT_PKG_MQTT_THREAD_STACK_SIZE < 6144)
+#error "MQTT using tls, please increase MQTT thread stack size up to 6K via menuconfig tool!"
+#endif
+#endif
+
 static uint16_t pub_port = 7000;
 
 /*


### PR DESCRIPTION
修复潜在的未定义 RT_PKG_MQTT_THREAD_STACK_SIZE 造成的编译错误。并为使用TLS连接的时候增加堆栈大小检查

Signed-off-by: MurphyZhao <d2014zjt@163.com>