### PR TITLE
清理不安全的类型强制转换，防止产生非对齐错误。

### DIFF
--- a/MQTTClient-RT/paho_mqtt_pipe.c
+++ b/MQTTClient-RT/paho_mqtt_pipe.c
@@ -591,13 +591,14 @@ static int MQTTSubscribe(MQTTClient *c, const char *topicFilter, enum QoS qos)
 {
     int rc = PAHO_FAILURE;
     int len = 0;
+    int qos_sub = qos;
     MQTTString topic = MQTTString_initializer;
     topic.cstring = (char *)topicFilter;
 
     if (!c->isconnected)
         goto _exit;
 
-    len = MQTTSerialize_subscribe(c->buf, c->buf_size, 0, getNextPacketId(c), 1, &topic, (int *)&qos);
+    len = MQTTSerialize_subscribe(c->buf, c->buf_size, 0, getNextPacketId(c), 1, &topic, &qos_sub);
     if (len <= 0)
         goto _exit;
     if ((rc = sendPacket(c, len)) != PAHO_SUCCESS) // send the subscribe packet

--- a/MQTTClient-RT/paho_mqtt_udp.c
+++ b/MQTTClient-RT/paho_mqtt_udp.c
@@ -448,13 +448,14 @@ static int MQTTSubscribe(MQTTClient *c, const char *topicFilter, enum QoS qos)
 {
     int rc = PAHO_FAILURE;
     int len = 0;
+    int qos_sub = qos;
     MQTTString topic = MQTTString_initializer;
     topic.cstring = (char *)topicFilter;
 
     if (!c->isconnected)
         goto _exit;
 
-    len = MQTTSerialize_subscribe(c->buf, c->buf_size, 0, getNextPacketId(c), 1, &topic, (int *)&qos);
+    len = MQTTSerialize_subscribe(c->buf, c->buf_size, 0, getNextPacketId(c), 1, &topic, &qos_sub);
     if (len <= 0)
         goto _exit;
     if ((rc = sendPacket(c, len)) != PAHO_SUCCESS) // send the subscribe packet


### PR DESCRIPTION
枚举类型的长度不确定，有可能产生非对齐错误。