### PR TITLE
[HUST CSE] fix: uniform variable name

### DIFF
--- a/MQTTClient-RT/paho_mqtt.h
+++ b/MQTTClient-RT/paho_mqtt.h
@@ -123,12 +123,12 @@ int paho_mqtt_start(MQTTClient *client);
  * @note it will be discarded, recommend to use "paho_mqtt_publish"
  *
  * @param client the pointer of MQTT context structure
- * @param topicName topic filter name
+ * @param topic topic filter name
  * @param message the pointer of MQTTMessage structure
  *
  * @return the error code, 0 on subscribe successfully.
  */
-int MQTTPublish(MQTTClient *client, const char *topicName, MQTTMessage *message);
+int MQTTPublish(MQTTClient *client, const char *topic, MQTTMessage *message);
 
 #ifdef PAHOMQTT_PIPE_MODE
 

--- a/MQTTClient-RT/paho_mqtt.h
+++ b/MQTTClient-RT/paho_mqtt.h
@@ -122,13 +122,13 @@ int paho_mqtt_start(MQTTClient *client);
  * This function publish message to specified mqtt topic.
  * @note it will be discarded, recommend to use "paho_mqtt_publish"
  *
- * @param c the pointer of MQTT context structure
- * @param topicFilter topic filter name
+ * @param client the pointer of MQTT context structure
+ * @param topicName topic filter name
  * @param message the pointer of MQTTMessage structure
  *
  * @return the error code, 0 on subscribe successfully.
  */
-int MQTTPublish(MQTTClient *client, const char *topic, MQTTMessage *message);
+int MQTTPublish(MQTTClient *client, const char *topicName, MQTTMessage *message);
 
 #ifdef PAHOMQTT_PIPE_MODE
 
@@ -166,7 +166,7 @@ int paho_mqtt_unsubscribe(MQTTClient *client, const char *topic);
 /**
  * This function publish message to specified mqtt topic.
  *
- * @param c the pointer of MQTT context structure
+ * @param client the pointer of MQTT context structure
  * @param qos MQTT QOS type, only support QOS1
  * @param topic topic filter name
  * @param msg_str the pointer of send message
@@ -178,7 +178,7 @@ int paho_mqtt_publish(MQTTClient *client, enum QoS qos, const char *topic, const
 /**
  * This function control MQTT client configure, such as connect timeout, reconnect interval.
  *
- * @param c the pointer of MQTT context structure
+ * @param client the pointer of MQTT context structure
  * @param cmd control configure type, 'mqttControl' enumeration shows the supported configure types.
  * @param arg the pointer of argument
  *

--- a/MQTTClient-RT/paho_mqtt_pipe.c
+++ b/MQTTClient-RT/paho_mqtt_pipe.c
@@ -915,12 +915,12 @@ _exit:
  * [MQTTMessage] + [payload] + [topic] + '\0'
  *
  * @param client the pointer of MQTT context structure
- * @param topicName topic filter name
+ * @param topic topic filter name
  * @param message the pointer of MQTTMessage structure
  *
  * @return the error code, 0 on subscribe successfully.
  */
-int MQTTPublish(MQTTClient *client, const char *topicName, MQTTMessage *message)
+int MQTTPublish(MQTTClient *client, const char *topic, MQTTMessage *message)
 {
     int rc = PAHO_FAILURE;
     int len, msg_len;
@@ -929,14 +929,14 @@ int MQTTPublish(MQTTClient *client, const char *topicName, MQTTMessage *message)
     if (!client->isconnected)
         goto exit;
 
-    msg_len = sizeof(MQTTMessage) + message->payloadlen + strlen(topicName) + 1;
+    msg_len = sizeof(MQTTMessage) + message->payloadlen + strlen(topic) + 1;
     data = rt_malloc(msg_len);
     if (!data)
         goto exit;
 
     rt_memcpy(data, message, sizeof(MQTTMessage));
     rt_memcpy(data + sizeof(MQTTMessage), message->payload, message->payloadlen);
-    strcpy(data + sizeof(MQTTMessage) + message->payloadlen, topicName);
+    strcpy(data + sizeof(MQTTMessage) + message->payloadlen, topic);
 
 
     len = MQTT_local_send(client, data, msg_len);

--- a/MQTTClient-RT/paho_mqtt_pipe.c
+++ b/MQTTClient-RT/paho_mqtt_pipe.c
@@ -914,19 +914,19 @@ _exit:
  * This function publish message to specified mqtt topic.
  * [MQTTMessage] + [payload] + [topic] + '\0'
  *
- * @param c the pointer of MQTT context structure
- * @param topicFilter topic filter name
+ * @param client the pointer of MQTT context structure
+ * @param topicName topic filter name
  * @param message the pointer of MQTTMessage structure
  *
  * @return the error code, 0 on subscribe successfully.
  */
-int MQTTPublish(MQTTClient *c, const char *topicName, MQTTMessage *message)
+int MQTTPublish(MQTTClient *client, const char *topicName, MQTTMessage *message)
 {
     int rc = PAHO_FAILURE;
     int len, msg_len;
     char *data = 0;
 
-    if (!c->isconnected)
+    if (!client->isconnected)
         goto exit;
 
     msg_len = sizeof(MQTTMessage) + message->payloadlen + strlen(topicName) + 1;
@@ -939,7 +939,7 @@ int MQTTPublish(MQTTClient *c, const char *topicName, MQTTMessage *message)
     strcpy(data + sizeof(MQTTMessage) + message->payloadlen, topicName);
 
 
-    len = MQTT_local_send(c, data, msg_len);
+    len = MQTT_local_send(client, data, msg_len);
     if (len == msg_len)
     {
         rc = PAHO_SUCCESS;
@@ -1388,7 +1388,7 @@ _exit:
 /**
  * This function publish message to specified mqtt topic.
  *
- * @param c the pointer of MQTT context structure
+ * @param client the pointer of MQTT context structure
  * @param qos MQTT QOS type, only support QOS1
  * @param topic topic filter name
  * @param msg_str the pointer of MQTTMessage structure
@@ -1424,7 +1424,7 @@ int paho_mqtt_publish(MQTTClient *client, enum QoS qos, const char *topic, const
 /**
  * This function control MQTT client configure, such as connect timeout, reconnect interval.
  *
- * @param c the pointer of MQTT context structure
+ * @param client the pointer of MQTT context structure
  * @param cmd control configure type, 'mqttControl' enumeration shows the supported configure types.
  * @param arg the pointer of argument
  *

--- a/MQTTClient-RT/paho_mqtt_udp.c
+++ b/MQTTClient-RT/paho_mqtt_udp.c
@@ -956,12 +956,12 @@ _exit:
  * [MQTTMessage] + [payload] + [topic] + '\0'
  *
  * @param client the pointer of MQTT context structure
- * @param topicName topic filter name
+ * @param topic topic filter name
  * @param message the pointer of MQTTMessage structure
  *
  * @return the error code, 0 on subscribe successfully.
  */
-int MQTTPublish(MQTTClient *client, const char *topicName, MQTTMessage *message)
+int MQTTPublish(MQTTClient *client, const char *topic, MQTTMessage *message)
 {
     int rc = PAHO_FAILURE;
     int len, msg_len;
@@ -970,14 +970,14 @@ int MQTTPublish(MQTTClient *client, const char *topicName, MQTTMessage *message)
     if (!client->isconnected)
         goto exit;
 
-    msg_len = sizeof(MQTTMessage) + message->payloadlen + strlen(topicName) + 1;
+    msg_len = sizeof(MQTTMessage) + message->payloadlen + strlen(topic) + 1;
     data = rt_malloc(msg_len);
     if (!data)
         goto exit;
 
     rt_memcpy(data, message, sizeof(MQTTMessage));
     rt_memcpy(data + sizeof(MQTTMessage), message->payload, message->payloadlen);
-    strcpy(data + sizeof(MQTTMessage) + message->payloadlen, topicName);
+    strcpy(data + sizeof(MQTTMessage) + message->payloadlen, topic);
 
     len = MQTT_local_send(client, data, msg_len);
     if (len == msg_len)

--- a/MQTTClient-RT/paho_mqtt_udp.c
+++ b/MQTTClient-RT/paho_mqtt_udp.c
@@ -955,19 +955,19 @@ _exit:
  * This function publish message to specified mqtt topic.
  * [MQTTMessage] + [payload] + [topic] + '\0'
  *
- * @param c the pointer of MQTT context structure
- * @param topicFilter topic filter name
+ * @param client the pointer of MQTT context structure
+ * @param topicName topic filter name
  * @param message the pointer of MQTTMessage structure
  *
  * @return the error code, 0 on subscribe successfully.
  */
-int MQTTPublish(MQTTClient *c, const char *topicName, MQTTMessage *message)
+int MQTTPublish(MQTTClient *client, const char *topicName, MQTTMessage *message)
 {
     int rc = PAHO_FAILURE;
     int len, msg_len;
     char *data = 0;
 
-    if (!c->isconnected)
+    if (!client->isconnected)
         goto exit;
 
     msg_len = sizeof(MQTTMessage) + message->payloadlen + strlen(topicName) + 1;
@@ -979,7 +979,7 @@ int MQTTPublish(MQTTClient *c, const char *topicName, MQTTMessage *message)
     rt_memcpy(data + sizeof(MQTTMessage), message->payload, message->payloadlen);
     strcpy(data + sizeof(MQTTMessage) + message->payloadlen, topicName);
 
-    len = MQTT_local_send(c, data, msg_len);
+    len = MQTT_local_send(client, data, msg_len);
     if (len == msg_len)
     {
         rc = 0;

--- a/MQTTPacket/src/MQTTPacket.h
+++ b/MQTTPacket/src/MQTTPacket.h
@@ -98,7 +98,7 @@ int MQTTSerialize_ack(unsigned char* buf, int buflen, unsigned char type, unsign
 int MQTTDeserialize_ack(unsigned char* packettype, unsigned char* dup, unsigned short* packetid, unsigned char* buf, int buflen);
 
 int MQTTPacket_len(int rem_len);
-int MQTTPacket_equals(MQTTString* a, char* b);
+int MQTTPacket_equals(MQTTString* a, char* bptr);
 
 int MQTTPacket_encode(unsigned char* buf, int length);
 int MQTTPacket_decode(int (*getcharfn)(unsigned char*, int), int* value);

--- a/MQTTPacket/src/MQTTPublish.h
+++ b/MQTTPacket/src/MQTTPublish.h
@@ -29,7 +29,7 @@ DLLExport int MQTTSerialize_publish(unsigned char* buf, int buflen, unsigned cha
         MQTTString topicName, unsigned char* payload, int payloadlen);
 
 DLLExport int MQTTDeserialize_publish(unsigned char* dup, int* qos, unsigned char* retained, unsigned short* packetid, MQTTString* topicName,
-        unsigned char** payload, int* payloadlen, unsigned char* buf, int len);
+        unsigned char** payload, int* payloadlen, unsigned char* buf, int buflen);
 
 DLLExport int MQTTSerialize_puback(unsigned char* buf, int buflen, unsigned short packetid);
 DLLExport int MQTTSerialize_pubrel(unsigned char* buf, int buflen, unsigned char dup, unsigned short packetid);

--- a/MQTTPacket/src/MQTTSerializePublish.c
+++ b/MQTTPacket/src/MQTTSerializePublish.c
@@ -102,7 +102,7 @@ exit:
   * @param packetid the MQTT packet identifier
   * @return serialized length, or error if 0
   */
-int MQTTSerialize_ack(unsigned char* buf, int buflen, unsigned char packettype, unsigned char dup, unsigned short packetid)
+int MQTTSerialize_ack(unsigned char* buf, int buflen, unsigned char type, unsigned char dup, unsigned short packetid)
 {
     MQTTHeader header = {0};
     int rc = 0;
@@ -114,9 +114,9 @@ int MQTTSerialize_ack(unsigned char* buf, int buflen, unsigned char packettype, 
         rc = MQTTPACKET_BUFFER_TOO_SHORT;
         goto exit;
     }
-    header.bits.type = packettype;
+    header.bits.type = type;
     header.bits.dup = dup;
-    header.bits.qos = (packettype == PUBREL) ? 1 : 0;
+    header.bits.qos = (type == PUBREL) ? 1 : 0;
     writeChar(&ptr, header.byte); /* write header */
 
     ptr += MQTTPacket_encode(ptr, 2); /* write remaining length */

--- a/MQTTPacket/src/MQTTSubscribe.h
+++ b/MQTTPacket/src/MQTTSubscribe.h
@@ -29,11 +29,11 @@ DLLExport int MQTTSerialize_subscribe(unsigned char* buf, int buflen, unsigned c
         int count, MQTTString topicFilters[], int requestedQoSs[]);
 
 DLLExport int MQTTDeserialize_subscribe(unsigned char* dup, unsigned short* packetid,
-        int maxcount, int* count, MQTTString topicFilters[], int requestedQoSs[], unsigned char* buf, int len);
+        int maxcount, int* count, MQTTString topicFilters[], int requestedQoSs[], unsigned char* buf, int buflen);
 
 DLLExport int MQTTSerialize_suback(unsigned char* buf, int buflen, unsigned short packetid, int count, int* grantedQoSs);
 
-DLLExport int MQTTDeserialize_suback(unsigned short* packetid, int maxcount, int* count, int grantedQoSs[], unsigned char* buf, int len);
+DLLExport int MQTTDeserialize_suback(unsigned short* packetid, int maxcount, int* count, int grantedQoSs[], unsigned char* buf, int buflen);
 
 
 #endif /* MQTTSUBSCRIBE_H_ */

--- a/MQTTPacket/src/MQTTUnsubscribe.h
+++ b/MQTTPacket/src/MQTTUnsubscribe.h
@@ -28,11 +28,11 @@
 DLLExport int MQTTSerialize_unsubscribe(unsigned char* buf, int buflen, unsigned char dup, unsigned short packetid,
         int count, MQTTString topicFilters[]);
 
-DLLExport int MQTTDeserialize_unsubscribe(unsigned char* dup, unsigned short* packetid, int max_count, int* count, MQTTString topicFilters[],
-        unsigned char* buf, int len);
+DLLExport int MQTTDeserialize_unsubscribe(unsigned char* dup, unsigned short* packetid, int maxcount, int* count, MQTTString topicFilters[],
+        unsigned char* buf, int buflen);
 
 DLLExport int MQTTSerialize_unsuback(unsigned char* buf, int buflen, unsigned short packetid);
 
-DLLExport int MQTTDeserialize_unsuback(unsigned short* packetid, unsigned char* buf, int len);
+DLLExport int MQTTDeserialize_unsuback(unsigned short* packetid, unsigned char* buf, int buflen);
 
 #endif /* MQTTUNSUBSCRIBE_H_ */

--- a/MQTTPacket/src/MQTTUnsubscribeServer.c
+++ b/MQTTPacket/src/MQTTUnsubscribeServer.c
@@ -32,7 +32,7 @@
   * @return the length of the serialized data.  <= 0 indicates error
   */
 int MQTTDeserialize_unsubscribe(unsigned char* dup, unsigned short* packetid, int maxcount, int* count, MQTTString topicFilters[],
-        unsigned char* buf, int len)
+        unsigned char* buf, int buflen)
 {
     MQTTHeader header = {0};
     unsigned char* curdata = buf;


### PR DESCRIPTION
将注释和代码中的变量名进行统一