### PR TITLE
[HUST CSE] fix: func "paho_mqtt_start" return value

### DIFF
--- a/MQTTClient-RT/paho_mqtt_pipe.c
+++ b/MQTTClient-RT/paho_mqtt_pipe.c
@@ -1218,11 +1218,13 @@ int paho_mqtt_start(MQTTClient *client)
                             paho_mqtt_thread, (void *) client,      // fun, parameter
                             RT_PKG_MQTT_THREAD_STACK_SIZE,          // stack size
                             RT_THREAD_PRIORITY_MAX / 3, 2 );         //priority, tick
-    if (tid)
+    if (tid == RT_NULL)
     {
-        rt_thread_startup(tid);
+        LOG_E("Create MQTT thread error.");
+        return PAHO_FAILURE;
     }
 
+    rt_thread_startup(tid);
     return PAHO_SUCCESS;
 }
 


### PR DESCRIPTION
修复了 `paho_mqtt_start` 函数返回值的处理，在 `tid = rt_thread_create` 失败后，让函数返回 `PAHO_FAILURE`，而非 `PAHO_SUCCESS`。`LOG_E` 参考了上文1211行的异常处理。