### PR TITLE
fix MQTTClient-RT/paho_mqtt_udp.c function naming error2

### DIFF
--- a/MQTTClient-RT/paho_mqtt_pipe.c
+++ b/MQTTClient-RT/paho_mqtt_pipe.c
@@ -929,7 +929,6 @@ int MQTTPublish(MQTTClient *client, const char *topic, MQTTMessage *message)
     if (!client->isconnected)
         goto exit;
 
-
     msg_len = sizeof(MQTTMessage) + message->payloadlen + strlen(topic) + 1;
     if(msg_len >= client->buf_size)
     {

--- a/MQTTClient-RT/paho_mqtt_udp.c
+++ b/MQTTClient-RT/paho_mqtt_udp.c
@@ -975,9 +975,9 @@ int MQTTPublish(MQTTClient *client, const char *topic, MQTTMessage *message)
         goto exit;
 
     msg_len = sizeof(MQTTMessage) + message->payloadlen + strlen(topic) + 1;
-     if(msg_len >= c->buf_size)
+     if(msg_len >= client->buf_size)
     {
-        LOG_E("Message is too long %d:%d.", msg_len, c->buf_size);
+        LOG_E("Message is too long %d:%d.", msg_len, client->buf_size);
         rc = PAHO_BUFFER_OVERFLOW;
         goto exit;
     }


### PR DESCRIPTION
The function defined in line 968 of paho_mqtt_udp.c uses an incorrect variable name.